### PR TITLE
changed disabling of trajectory controllers to controller_manager sto…

### DIFF
--- a/hsr_velocity_controller/launch/switch_to_velocity_controllers.launch
+++ b/hsr_velocity_controller/launch/switch_to_velocity_controllers.launch
@@ -5,8 +5,8 @@
  <rosparam file="$(find hsr_velocity_controller)/config/my_controller_realtime_test.yaml" command="load"/>
 
  <!-- disable trajectory controllers -->
- <node name="controller_unspawner" pkg="controller_manager" type="unspawner" respawn="false"
-       output="screen" ns="/hsrb" args="arm_trajectory_controller head_trajectory_controller"/>
+ <node name="controller_unspawner" pkg="controller_manager" type="controller_manager" respawn="false"
+       output="screen" ns="/hsrb" args="stop arm_trajectory_controller head_trajectory_controller"/>
        
  <!-- load the controllers -->
  <node name="realtime_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"


### PR DESCRIPTION
…p instead of unspawner, because you can't restart controllers while using unspawner.
Should fix the issue, that prevents the PlayStation Controller and Giskardpy from setting up the controllers correctly for the real_time launch file.